### PR TITLE
iOS 8 CFPreferences and application whitelist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.deb
-_/
-obj/
-.theos/
+_
+obj
+.theos
 .DS_Store
+theos
+

--- a/BBBulletin.h
+++ b/BBBulletin.h
@@ -1,0 +1,5 @@
+@interface BBBulletin : NSObject
+- (id)title;
+-(NSString *)sectionID;
+@end
+

--- a/FSSwitchDataSource.h
+++ b/FSSwitchDataSource.h
@@ -1,0 +1,54 @@
+#import <UIKit/UIKit.h>
+#import "FSSwitchState.h"
+
+@protocol FSSwitchDataSource <NSObject>
+@optional
+
+- (FSSwitchState)stateForSwitchIdentifier:(NSString *)switchIdentifier;
+// Gets the current state of the switch.
+// Must override if building a settings-like switch.
+// Return FSSwitchStateIndeterminate if switch is loading
+// By default returns FSSwitchStateIndeterminate
+
+- (void)applyState:(FSSwitchState)newState forSwitchIdentifier:(NSString *)switchIdentifier;
+// Sets the new state of the switch
+// Must override if building a settings-like switch.
+// By default calls through to applyActionForSwitchIdentifier: if newState is different from the current state
+
+- (void)applyActionForSwitchIdentifier:(NSString *)switchIdentifier;
+// Runs the default action for the switch.
+// Must override if building an action-like switch.
+// By default calls through to applyState:forSwitchIdentifier: if state is not indeterminate
+
+- (NSString *)titleForSwitchIdentifier:(NSString *)switchIdentifier;
+// Returns the localized title for the switch.
+// By default reads the CFBundleDisplayName out of the switch's bundle.
+
+- (BOOL)shouldShowSwitchIdentifier:(NSString *)switchIdentifier;
+// Returns wether the switch should be shown.
+// By default returns YES or the value from GraphicsServices for the capability specified in the "required-capability-key" of the switch's bundle
+// E.g. You would detect if the device has the required capability (3G, flash etc)
+
+- (id)glyphImageDescriptorOfState:(FSSwitchState)switchState size:(CGFloat)size scale:(CGFloat)scale forSwitchIdentifier:(NSString *)switchIdentifier;
+// Provide an image descriptor that best displays at the requested size and scale
+// By default looks through the bundle to find a glyph image
+
+- (NSBundle *)bundleForSwitchIdentifier:(NSString *)switchIdentifier;
+// Provides a bundle to look for localizations/images in
+// By default returns the bundle for the current class
+
+- (void)switchWasRegisteredForIdentifier:(NSString *)switchIdentifier;
+// Called when switch is first registered
+
+- (void)switchWasUnregisteredForIdentifier:(NSString *)switchIdentifier;
+// Called when switch is unregistered
+
+- (BOOL)hasAlternateActionForSwitchIdentifier:(NSString *)switchIdentifier;
+// Gets whether the switch supports an alternate or "hold" action
+// By default queries if switch responds to applyAlternateActionForSwitchIdentifier: or if it has a "alternate-action-url" key set
+
+- (void)applyAlternateActionForSwitchIdentifier:(NSString *)switchIdentifier;
+// Applies the alternate or "hold" action
+// By default launches the URL stored in the "alternate-action-url" key of the switch's bundle
+
+@end

--- a/FSSwitchPanel.h
+++ b/FSSwitchPanel.h
@@ -1,0 +1,58 @@
+#import <UIKit/UIKit.h>
+#import "FSSwitchState.h"
+
+@interface FSSwitchPanel : NSObject
+
++ (FSSwitchPanel *)sharedPanel;
+
+@property (nonatomic, readonly, copy) NSArray *switchIdentifiers;
+// Returns a list of identifying all switches installed on the device
+
+- (NSString *)titleForSwitchIdentifier:(NSString *)switchIdentifier;
+// Returns the localized title for a specific switch
+
+- (UIButton *)buttonForSwitchIdentifier:(NSString *)switchIdentifier usingTemplate:(NSBundle *)templateBundle;
+// Returns a UIButton for a specific switch
+// The button automatically updates its style based on the user interaction and switch state changes, applies the standard action when pressed, and applies the alternate action when held
+
+- (UIImage *)imageOfSwitchState:(FSSwitchState)state controlState:(UIControlState)controlState forSwitchIdentifier:(NSString *)switchIdentifier usingTemplate:(NSBundle *)templateBundle;
+- (UIImage *)imageOfSwitchState:(FSSwitchState)state controlState:(UIControlState)controlState scale:(CGFloat)scale forSwitchIdentifier:(NSString *)switchIdentifier usingTemplate:(NSBundle *)templateBundle;
+// Returns an image representing how a specific switch would look in a particular state when styled with the provided template
+
+- (id)glyphImageDescriptorOfState:(FSSwitchState)switchState size:(CGFloat)size scale:(CGFloat)scale forSwitchIdentifier:(NSString *)switchIdentifier;
+// Returns the raw glyph identifier as retrieved from the backing FSSwitch instance
+
+- (FSSwitchState)stateForSwitchIdentifier:(NSString *)switchIdentifier;
+// Returns the current state of a particualr switch
+- (void)setState:(FSSwitchState)state forSwitchIdentifier:(NSString *)switchIdentifier;
+// Updates the state of a particular switch. If the switch accepts the change it will send a state change
+- (void)applyActionForSwitchIdentifier:(NSString *)switchIdentifier;
+// Applies the default action of a particular switch
+
+- (BOOL)hasAlternateActionForSwitchIdentifier:(NSString *)switchIdentifier;
+// Queries whether a switch supports an alternate action. This is often triggered by a hold gesture
+- (void)applyAlternateActionForSwitchIdentifier:(NSString *)switchIdentifier;
+// Apply the alternate action of a particular switch
+
+- (void)openURLAsAlternateAction:(NSURL *)url;
+// Helper method to open a particular URL as if it were launched from an alternate action
+
+@end
+
+@protocol FSSwitchDataSource;
+
+@interface FSSwitchPanel (SpringBoard)
+- (void)registerDataSource:(id<FSSwitchDataSource>)dataSource forSwitchIdentifier:(NSString *)switchIdentifier;
+// Registers a switch implementation for a specific identifier. Bundlee in /Library/Switches will have their principal class automatically loaded
+- (void)unregisterSwitchIdentifier:(NSString *)switchIdentifier;
+// Unregisters a switch
+- (void)stateDidChangeForSwitchIdentifier:(NSString *)switchIdentifier;
+// Informs the system when a switch changes its state. This will trigger any switch buttons to update their style
+@end
+
+extern NSString * const FSSwitchPanelSwitchesChangedNotification;
+
+extern NSString * const FSSwitchPanelSwitchStateChangedNotification;
+extern NSString * const FSSwitchPanelSwitchIdentifierKey;
+
+extern NSString * const FSSwitchPanelSwitchWillOpenURLNotification;

--- a/FSSwitchState.h
+++ b/FSSwitchState.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+typedef enum {
+	FSSwitchStateOff = 0,
+	FSSwitchStateOn = 1,
+	FSSwitchStateIndeterminate = -1
+} FSSwitchState;
+
+extern NSString *NSStringFromFSSwitchState(FSSwitchState state);
+extern FSSwitchState FSSwitchStateFromNSString(NSString *stateString);

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
-THEOS_DEVICE_IP = 192.168.7.146
-THEOS_DEVICE_PORT = 22
+ARCHS = armv7 armv7s arm64
+TARGET = iphone:clang:latest:latest
 
 include theos/makefiles/common.mk
-
-ARCHS=armv7 armv7s arm64
 
 TWEAK_NAME = OnlyOneNotification
 OnlyOneNotification_FILES = Tweak.xm

--- a/onlyonenotificationflipswitch/Switch.x
+++ b/onlyonenotificationflipswitch/Switch.x
@@ -5,25 +5,25 @@
 @interface OnlyOneNotificationFlipswitchSwitch : NSObject <FSSwitchDataSource>
 @end
 
+@interface NSUserDefaults (Private)
+- (instancetype)_initWithSuiteName:(NSString *)suiteName container:(NSURL *)container;
+@end
+
 @implementation OnlyOneNotificationFlipswitchSwitch
 
 - (FSSwitchState)stateForSwitchIdentifier:(NSString *)switchIdentifier
 {
-    NSDictionary *prefs = [NSDictionary 
-        dictionaryWithContentsOfFile:@"/var/mobile/Library/Preferences/com.lodc.ios.oonsettings.plist"];
-    if ([prefs objectForKey:@"enabled"] != nil)
-        return [[prefs objectForKey:@"enabled"] boolValue] ? FSSwitchStateOn : FSSwitchStateOff;
-    else
-        return FSSwitchStateOn;
+	id obj = CFPreferencesCopyAppValue(CFSTR("enabled"), CFSTR("com.lodc.ios.oonsettings"));
+	BOOL state = obj ? [obj boolValue] : YES;
+    return (state) ? FSSwitchStateOn : FSSwitchStateOff;
 }
 
 - (void)applyState:(FSSwitchState)newState forSwitchIdentifier:(NSString *)switchIdentifier
 {
     if (newState == FSSwitchStateIndeterminate)
         return;
-    NSMutableDictionary *prefs = [NSMutableDictionary dictionaryWithContentsOfFile:@"/var/mobile/Library/Preferences/com.lodc.ios.oonsettings.plist"];
-    [prefs setObject:[NSNumber numberWithBool:newState] forKey:@"enabled"];
-    [prefs writeToFile:@"/var/mobile/Library/Preferences/com.lodc.ios.oonsettings.plist" atomically:YES];
+    CFBooleanRef newValue = (BOOL)newState ? kCFBooleanTrue : kCFBooleanFalse;
+    CFPreferencesSetAppValue ( CFSTR("enabled"), newValue, CFSTR("com.lodc.ios.oonsettings") );
     notify_post("com.lodc.ios.oon/reloadSettings");
 }
 

--- a/onlyonenotificationflipswitch/theos
+++ b/onlyonenotificationflipswitch/theos
@@ -1,1 +1,1 @@
-/opt/theos-rpetrich
+/Users/milodarling/theos

--- a/oonsettings/Resources/OONSettings.plist
+++ b/oonsettings/Resources/OONSettings.plist
@@ -108,6 +108,39 @@
 			<key>PostNotification</key>
 			<string>com.lodc.ios.oon/reloadSettings</string>
 		</dict> 
+		<dict>
+			<key>cell</key>
+			<string>PSLinkCell</string>
+			<key>bundle</key>
+			<string>AppList</string>
+			<key>isController</key>
+			<true/>
+			<key>label</key>
+			<string>Whitelisted Apps</string>
+			<key>ALSettingsPath</key>
+			<string>/var/mobile/Library/Preferences/com.lodc.ios.oonsettings.plist</string>
+			<key>ALSettingsKeyPrefix</key>
+			<string>blacklisted-</string>
+			<key>ALChangeNotification</key>
+			<string>com.lodc.ios.oon/reloadSettings</string>
+			<key>ALAllowsSelection</key>
+			<true/>
+			<key>ALSectionDescriptors</key>
+			<array>
+				<dict>
+					<key>title</key>
+					<string>Whitelisted apps</string>
+					<key>cell-class-name</key>
+					<string>ALCheckCell</string>
+					<key>suppress-hidden-apps</key>
+					<true/>
+					<key>icon-size</key>
+					<integer>29</integer>
+					<key>footer-title</key>
+					<string>These apps' notifications will be shown no matter what. Check clock for alarms to be heard.</string>
+				</dict>
+			</array>
+		</dict>
                 <dict>
 			<key>cell</key>
 			<string>PSGroupCell</string>

--- a/oonsettings/theos
+++ b/oonsettings/theos
@@ -1,1 +1,1 @@
-/opt/theos-rpetrich
+/Users/milodarling/theos


### PR DESCRIPTION
I added a whitelist for applications so that their notifications cause alerts no matter what, because I realized that the Clock app's alarms were being silenced, and I decided to just let the user set any app to whitelist. I also implemented iOS 8's CFPreferences APIs due to the change in cfprefsd in iOS 8. Also, if you submit this to BigBoss (which you hopefully do :D), be sure to remove `#define DEBUG` from Tweak.xm if you don't want that logging to go into the public build. 
